### PR TITLE
Improve _auto_discover to support PyInstaller and packaged environments

### DIFF
--- a/src/eyetrax/models/__init__.py
+++ b/src/eyetrax/models/__init__.py
@@ -1,5 +1,5 @@
+import pkgutil
 from importlib import import_module
-from pathlib import Path
 from typing import Dict, Type
 
 from .base import BaseModel
@@ -16,12 +16,10 @@ def register_model(name: str, cls: Type[BaseModel]) -> None:
 
 
 def _auto_discover() -> None:
-    pkg_dir = Path(__file__).resolve().parent
-    for f in pkg_dir.iterdir():
-        if f.name in {"__init__.py", "base.py"} or f.suffix != ".py":
+    for _, mod_name, _ in pkgutil.iter_modules(__path__):
+        if mod_name == "base":
             continue
-        mod_name = f"{__name__}.{f.stem}"
-        import_module(mod_name)
+        import_module(f"{__name__}.{mod_name}")
 
 
 def create_model(name: str, **kwargs) -> BaseModel:


### PR DESCRIPTION
Thank you for all your work on this project, it’s been really interesting and fun to use!

I noticed that the current `_auto_discover` in `models/__init__.py` goes through the filesystem directly, which works fine in most normal scenarios but breaks when the package is bundled, like with Pyinstaller, since the .py files probably won't actually exist on disk.

I thought that I would make this small PR that switches `_auto_discover` to use `pkgutil.iter_modules(__path__)`, which works in both normal and bundled setups and still keeps all of the original behaviour.

Let me know what you think!