### PR TITLE
Add multi-monitor support to calibration

### DIFF
--- a/src/eyetrax/app/demo.py
+++ b/src/eyetrax/app/demo.py
@@ -20,7 +20,7 @@ from eyetrax.filters import (
 )
 from eyetrax.gaze import GazeEstimator
 from eyetrax.utils.draw import draw_cursor, make_thumbnail
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import camera, fullscreen, iter_frames
 
 
@@ -55,7 +55,7 @@ def run_demo():
         else:
             run_lissajous_calibration(gaze_estimator, camera_index=camera_index)
 
-    screen_width, screen_height = get_screen_size()
+    _, _, screen_width, screen_height = get_monitor_geometry()
 
     if filter_method == "kalman":
         kalman = make_kalman()

--- a/src/eyetrax/app/virtualcam.py
+++ b/src/eyetrax/app/virtualcam.py
@@ -20,7 +20,7 @@ from eyetrax.filters import (
 )
 from eyetrax.gaze import GazeEstimator
 from eyetrax.utils.draw import draw_cursor
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import camera, iter_frames
 
 
@@ -54,7 +54,7 @@ def run_virtualcam():
         else:
             run_lissajous_calibration(gaze_estimator, camera_index=camera_index)
 
-    screen_width, screen_height = get_screen_size()
+    _, _, screen_width, screen_height = get_monitor_geometry()
 
     if filter_method == "kalman":
         kalman = make_kalman()

--- a/src/eyetrax/calibration/adaptive.py
+++ b/src/eyetrax/calibration/adaptive.py
@@ -10,7 +10,7 @@ import numpy as np
 from eyetrax.calibration.nine_point import run_9_point_calibration
 from eyetrax.gaze import GazeEstimator
 from eyetrax.utils.draw import draw_cursor
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 
@@ -93,15 +93,17 @@ def run_adaptive_calibration(
     retrain_every: int = 10,
     show_predictions: bool = True,
     camera_index: int = 0,
+    monitor_index: int = 0,
 ) -> None:
-    run_9_point_calibration(gaze_estimator, camera_index=camera_index)
+    run_9_point_calibration(gaze_estimator, camera_index=camera_index, monitor_index=monitor_index)
 
-    sw, sh = get_screen_size()
+    mx, my, sw, sh = get_monitor_geometry(monitor_index)
     sampler = BlueNoiseSampler(sw, sh)
     points = sampler.sample(num_random_points)
 
     cap = open_camera(camera_index)
     cv2.namedWindow("Adaptive Calibration", cv2.WND_PROP_FULLSCREEN)
+    cv2.moveWindow("Adaptive Calibration", mx, my)
     cv2.setWindowProperty(
         "Adaptive Calibration", cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_FULLSCREEN
     )

--- a/src/eyetrax/calibration/common.py
+++ b/src/eyetrax/calibration/common.py
@@ -56,7 +56,9 @@ def compute_grid_points_from_shape(
     return compute_grid_points(indices, sw, sh, margin_ratio)
 
 
-def wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, dur: int = 2) -> bool:
+def wait_for_face_and_countdown(
+    cap, gaze_estimator, sw: int, sh: int, mx: int, my: int, dur: int = 2
+) -> bool:
     """
     Waits for a face to be detected (not blinking), then shows a countdown ellipse
     """

--- a/src/eyetrax/calibration/common.py
+++ b/src/eyetrax/calibration/common.py
@@ -56,11 +56,12 @@ def compute_grid_points_from_shape(
     return compute_grid_points(indices, sw, sh, margin_ratio)
 
 
-def wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, dur: int = 2) -> bool:
+def wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, dur: int = 2) -> bool:
     """
     Waits for a face to be detected (not blinking), then shows a countdown ellipse
     """
     cv2.namedWindow("Calibration", cv2.WND_PROP_FULLSCREEN)
+    cv2.moveWindow("Calibration", mx, my)
     cv2.setWindowProperty("Calibration", cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_FULLSCREEN)
     fd_start = None
     countdown = False

--- a/src/eyetrax/calibration/dense_grid.py
+++ b/src/eyetrax/calibration/dense_grid.py
@@ -6,7 +6,7 @@ from eyetrax.calibration.common import (
     compute_grid_points_from_shape,
     wait_for_face_and_countdown,
 )
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 
@@ -20,14 +20,15 @@ def run_dense_grid_calibration(
     pulse_d: float = 0.9,
     cd_d: float = 0.9,
     camera_index: int = 0,
+    monitor_index: int = 0,
 ) -> None:
     """
     Dense grid calibration for higher spatial precision.
     """
-    sw, sh = get_screen_size()
+    mx, my, sw, sh = get_monitor_geometry(monitor_index)
 
     cap = open_camera(camera_index)
-    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, 2):
+    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, 2):
         cap.release()
         cv2.destroyAllWindows()
         return

--- a/src/eyetrax/calibration/five_point.py
+++ b/src/eyetrax/calibration/five_point.py
@@ -6,18 +6,20 @@ from eyetrax.calibration.common import (
     compute_grid_points,
     wait_for_face_and_countdown,
 )
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 
-def run_5_point_calibration(gaze_estimator, camera_index: int = 0):
+def run_5_point_calibration(
+    gaze_estimator, camera_index: int = 0, monitor_index: int = 0
+):
     """
     Faster five-point calibration
     """
-    sw, sh = get_screen_size()
+    mx, my, sw, sh = get_monitor_geometry(monitor_index)
 
     cap = open_camera(camera_index)
-    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, 2):
+    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, 2):
         cap.release()
         cv2.destroyAllWindows()
         return

--- a/src/eyetrax/calibration/lissajous.py
+++ b/src/eyetrax/calibration/lissajous.py
@@ -2,18 +2,20 @@ import cv2
 import numpy as np
 
 from eyetrax.calibration.common import wait_for_face_and_countdown
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 
-def run_lissajous_calibration(gaze_estimator, camera_index: int = 0):
+def run_lissajous_calibration(
+    gaze_estimator, camera_index: int = 0, monitor_index: int = 0
+):
     """
     Moves a calibration point along a Lissajous curve
     """
-    sw, sh = get_screen_size()
+    mx, my, sw, sh = get_monitor_geometry(monitor_index)
 
     cap = open_camera(camera_index)
-    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, 2):
+    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, 2):
         cap.release()
         cv2.destroyAllWindows()
         return

--- a/src/eyetrax/calibration/nine_point.py
+++ b/src/eyetrax/calibration/nine_point.py
@@ -6,18 +6,20 @@ from eyetrax.calibration.common import (
     compute_grid_points,
     wait_for_face_and_countdown,
 )
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 
-def run_9_point_calibration(gaze_estimator, camera_index: int = 0):
+def run_9_point_calibration(
+    gaze_estimator, camera_index: int = 0, monitor_index: int = 0
+):
     """
     Standard nine-point calibration
     """
-    sw, sh = get_screen_size()
+    mx, my, sw, sh = get_monitor_geometry(monitor_index)
 
     cap = open_camera(camera_index)
-    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, 2):
+    if not wait_for_face_and_countdown(cap, gaze_estimator, sw, sh, mx, my, 2):
         cap.release()
         cv2.destroyAllWindows()
         return

--- a/src/eyetrax/filters/kalman.py
+++ b/src/eyetrax/filters/kalman.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import cv2
 import numpy as np
 
-from eyetrax.utils.screen import get_screen_size
+from eyetrax.utils.screen import get_monitor_geometry
 from eyetrax.utils.video import open_camera
 
 from . import make_kalman
@@ -41,7 +41,7 @@ class KalmanSmoother(BaseSmoother):
         """
         Quick fine‑tuning pass to adjust Kalman filter's measurementNoiseCov
         """
-        screen_width, screen_height = get_screen_size()
+        _, _, screen_width, screen_height = get_monitor_geometry()
 
         points_tpl = [
             (screen_width // 2, screen_height // 4),

--- a/src/eyetrax/utils/screen.py
+++ b/src/eyetrax/utils/screen.py
@@ -8,4 +8,15 @@ def get_monitor_geometry(monitor_index: int = 0):
             f"Invalid monitor_index {monitor_index}, available: 0-{len(monitors)-1}"
         )
     m = monitors[monitor_index]
-    return m.x, m.y, m.width, m.height
+    
+    try:
+        x, y, width, height = int(m.x), int(m.y), int(m.width), int(m.height)
+    except (AttributeError, TypeError, ValueError):
+        raise ValueError(f"Invalid monitor data: {m}")
+
+    if width <= 0 or height <= 0:
+        raise ValueError(
+            f"Invalid monitor dimensions: width={width}, height={height}"
+        )
+
+    return x, y, width, height

--- a/src/eyetrax/utils/screen.py
+++ b/src/eyetrax/utils/screen.py
@@ -1,6 +1,11 @@
 from screeninfo import get_monitors
 
 
-def get_screen_size():
-    m = get_monitors()[0]
-    return m.width, m.height
+def get_monitor_geometry(monitor_index: int = 0):
+    monitors = get_monitors()
+    if monitor_index < 0 or monitor_index >= len(monitors):
+        raise ValueError(
+            f"Invalid monitor_index {monitor_index}, available: 0-{len(monitors)-1}"
+        )
+    m = monitors[monitor_index]
+    return m.x, m.y, m.width, m.height


### PR DESCRIPTION
Hello! I noticed that all calibration functions currently always use the primary monitor when determining screen geometry. This works fine in single-display setups, but can be limiting in multi-monitor environments where calibration may need to run on a specific or secondary screen.

I thought that I would make this small PR that adds support for selecting the target monitor via a `monitor_index` parameter when calling the calibration functions. The screen geometry is still fetched using `screeninfo.get_monitors()`, but now for the specified monitor, and the calibration window is explicitly moved to the selected display. The default behaviour remains unchanged, fetching the size of monitor 0, so this should remain fully backward compatible.

I’ve tested all the changed calibration functions locally (5-point, 9-point, dense grid, adaptive, and Lissajous), and they all appear to work correctly on different monitors without issues.

Let me know what you think!